### PR TITLE
makefile for windows

### DIFF
--- a/makefile.win
+++ b/makefile.win
@@ -1,0 +1,23 @@
+build ?= build
+CC = c++
+CFLAGS=-g -c -Wall -Iinclude/ -IwinLib
+vpath %.cpp src:src/titleScreen
+vpath %.h include
+#what are we compiling
+objects=$(build)/main.o $(build)/myLib.o\
+$(build)/titleScreen.o 
+
+all:$(build)/bin/hello.exe
+
+build:
+	@mkdir $(build)\bin 
+
+$(build)/bin/hello.exe:$(objects)
+	$(CC) $(build)/*.o -o $@ -lpdcurses -LwinLib
+		
+$(objects): $(build)/%.o:%.cpp| build 
+	 $(CC) $(CFLAGS) $< -o $@
+
+.PHONY: clean
+clean:
+	@rmdir /S $(build) 


### PR DESCRIPTION
Created a makefile for windows. The only requirement for building this
on windows is to install migwn and I would recommend adding the bin
folder to your path.
- open cmd
- navigate to where you have the hello the game repo
- rename makefile.win to makefile and backup the other makefile or
  delete it
- run mingw32-make all
  You should see:

```
    C:\path\to\repo>mingw32-make all
    c++ -g -c -Wall -Iinclude/ -IwinLib src/main.cpp -o build/main.o
    c++ -g -c -Wall -Iinclude/ -IwinLib src/myLib.cpp -o build/myLib.o
    c++ -g -c -Wall -Iinclude/ -IwinLib src/titleScreen/titleScreen.cpp -o build/titleScreen.o
    c++ build/*.o -o build/bin/hello.exe -lpdcurses -LwinLib
```
